### PR TITLE
update urls

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,8 @@
    tracker (not MoveIt!'s main tracker).
   </description>
 
-  <maintainer email="ablasdel@gmail.com">Aaron Blasdel</maintainer>
+  <maintainer email="iisaito@kinugarage.com">Isaac I.Y. Saito</maintainer>
+  <maintainer email="arne.hitzmann@gmail.com">Arne Hitzmann</maintainer>
   <author>Isaac Saito</author>
 
   <license>BSD</license>

--- a/package.xml
+++ b/package.xml
@@ -23,9 +23,9 @@
   <author>Isaac Saito</author>
 
   <license>BSD</license>
-  <url type="website">http://ros.org/wiki/rqt_moveit</url>
-  <url type="repository">https://github.com/ros-visualization/rqt_robot_plugins/rqt_moveit</url>
-  <url type="bugtracker">https://github.com/ros-visualization/rqt_robot_plugins/issues</url>
+  <url type="website">http://wiki.ros.org/rqt_moveit</url>
+  <url type="repository">https://github.com/ros-visualization/rqt_moveit</url>
+  <url type="bugtracker">https://github.com/ros-visualization/rqt_moveit/issues</url>
 
   <buildtool_depend>catkin</buildtool_depend>
   <run_depend version_gte="0.2.19">python_qt_binding</run_depend>


### PR DESCRIPTION
With the plugin being split out from `rqt_robot_plugins` I will do a last release for Lunar (as well as re-release for Kinetic, Jade, and Indigo) in the next days. After that I will stop watching this repo, not look at issues and pull requests, and not perform new releases.

Someone needs to take over the maintenance role which specifically includes doing new releases. @ablasdel You are currently listed in the manifest as the maintainer. I am not sure if you want to take this role and fully take over this repository? Or anyone else would like to step up (@arne48 @130s @davetcoleman since you have contributed to the package in the past)?

Please let me know if you want to be added / removed from the list of maintainers in the manifest. Otherwise I will go ahead and merge this as-is and release the package a last time setting the maintenance status to `unmaintained`.