### PR TITLE
fix shebang line for python3 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,6 @@ install(DIRECTORY resource
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-install(PROGRAMS scripts/rqt_moveit
+catkin_install_python(PROGRAMS scripts/rqt_moveit
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )


### PR DESCRIPTION
Similar to https://github.com/ros-visualization/rqt_graph/pull/43

Without this change the script cannot be rosrun on Noetic/Focal and results in:
`/usr/bin/env: ‘python’: No such file or directory`

Python scripts need to be installed using `catkin_install_python` for the shebang line to be rewritten to point to python3. More details at https://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>