### PR TITLE
xmlrpclib is renamed in python3

### DIFF
--- a/src/rqt_moveit/moveit_widget.py
+++ b/src/rqt_moveit/moveit_widget.py
@@ -35,7 +35,6 @@
 import os
 import sys
 import threading
-import xmlrpclib
 
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import QModelIndex, QTimer, Signal
@@ -45,6 +44,12 @@ import rospkg
 import rospy
 from rqt_py_common.rqt_roscomm_util import RqtRoscommUtil
 from rqt_topic.topic_widget import TopicWidget
+try:
+    # Python 2
+    from xmlrpclib import ServerProxy as XMLServerProxy
+except ModuleNotFoundError:
+    # Python 3
+    from xmlrpc.client import ServerProxy as XMLServerProxy
 
 
 class MoveitWidget(QWidget):
@@ -64,7 +69,7 @@ class MoveitWidget(QWidget):
         @type parent: MoveitMain
         """
 
-        self._ros_master = xmlrpclib.ServerProxy(os.environ['ROS_MASTER_URI'])
+        self._ros_master = XMLServerProxy(os.environ['ROS_MASTER_URI'])
         self._stop_event = threading.Event()
 
         self._nodes_monitored = ['/move_group']


### PR DESCRIPTION
Source of solution: https://stackoverflow.com/a/43750316

Fixes #8 